### PR TITLE
Adds freehand drawing tool

### DIFF
--- a/src/freehand/EditableFreehand.js
+++ b/src/freehand/EditableFreehand.js
@@ -1,0 +1,201 @@
+import EditableShape from '@recogito/annotorious/src/tools/EditableShape';
+import { drawEmbeddedSVG, toSVGTarget } from '@recogito/annotorious/src/selectors/EmbeddedSVG';
+import { SVG_NAMESPACE } from '@recogito/annotorious/src/util/SVG';
+import { format, setFormatterElSize } from '@recogito/annotorious/src/util/Formatting';
+//import { getFreehandSize, setFreehandSize } from './Freehand';
+//import Mask from './FreeDrawingMask';
+
+const getPoints = shape => {
+  const pointList = shape.querySelector('.a9s-inner').getAttribute('d').split('L');
+  const points = [];
+  if(pointList.length > 0) {
+    var point = pointList[0].substring(1).trim().split(' ');
+    points.push({ x: point[0], y: point[1] });
+
+    for (let i = 1; i < pointList.length; i++) {
+      var point = pointList[i].trim().split(' ');
+      points.push({ x: point[0], y: point[1] });
+    }
+  }
+
+  return points;
+}
+
+const getBBox = shape => {
+  return shape.querySelector('.a9s-inner').getBBox();
+}
+
+/**
+ * An editable free drawing.
+ */
+export default class EditableFreehand extends EditableShape {
+
+  constructor(annotation, g, config, env) {
+    super(annotation, g, config, env);
+
+    this.svg.addEventListener('mousemove', this.onMouseMove);
+    this.svg.addEventListener('mouseup', this.onMouseUp);
+
+    // SVG markup for this class looks like this:
+    // 
+    // <g>
+    //   <path class="a9s-selection mask"... />
+    //   <g> <-- return this node as .element
+    //     <polygon class="a9s-outer" ... />
+    //     <polygon class="a9s-inner" ... />
+    //     <g class="a9s-handle" ...> ... </g>
+    //     <g class="a9s-handle" ...> ... </g>
+    //     <g class="a9s-handle" ...> ... </g>
+    //     ...
+    //   </g> 
+    // </g>
+
+    // 'g' for the editable free drawing compound shape
+    this.containerGroup = document.createElementNS(SVG_NAMESPACE, 'g');
+
+    this.shape = drawEmbeddedSVG(annotation);
+    this.shape.querySelector('.a9s-inner')
+      .addEventListener('mousedown', this.onGrab(this.shape));
+
+//    this.mask = new Mask(env.image, this.shape.querySelector('.a9s-inner'));
+    
+//    this.containerGroup.appendChild(this.mask.element);
+
+    this.elementGroup = document.createElementNS(SVG_NAMESPACE, 'g');
+    this.elementGroup.setAttribute('class', 'a9s-annotation editable selected');
+    this.elementGroup.appendChild(this.shape);
+
+    const { x, y, width, height } = getBBox(this.shape);
+
+    this.handles = [
+      [ x, y ], 
+      [ x + width, y ], 
+      [ x + width, y + height ], 
+      [ x, y + height ]
+    ].map(t => { 
+      const [ x, y ] = t;
+      const handle = this.drawHandle(x, y);
+
+      handle.addEventListener('mousedown', this.onGrab(handle));
+      this.elementGroup.appendChild(handle);
+
+      return handle;
+    });
+
+    this.containerGroup.appendChild(this.elementGroup);
+    g.appendChild(this.containerGroup);
+
+    format(this.shape, annotation, config.formatter);
+
+    // The grabbed element (handle or entire shape), if any
+    this.grabbedElem = null;
+
+    // Mouse grab point
+    this.grabbedAt = null;
+  }
+
+  setPoints = (points) => {
+    // Not using .toFixed(1) because that will ALWAYS
+    // return one decimal, e.g. "15.0" (when we want "15")
+    const round = num => Math.round(10 * num) / 10;
+
+    var str = points.map(pt => `L${round(pt.x)} ${round(pt.y)}`).join(' ');
+    str = 'M' + str.substring(1);
+
+    const inner = this.shape.querySelector('.a9s-inner');
+    inner.setAttribute('d', str);
+
+    const outer = this.shape.querySelector('.a9s-outer');
+    outer.setAttribute('d', str);
+
+//    this.mask.redraw();
+
+    const { x, y, width, height } = outer.getBBox();
+    setFormatterElSize(this.elementGroup, x, y, width, height);
+  }
+
+  stretchCorners = (draggedHandleIdx, anchorHandle, mousePos) => {
+    //TODO implement
+/*    const anchor = this.getHandleXY(anchorHandle);
+
+    const width = mousePos.x - anchor.x;
+    const height = mousePos.y - anchor.y;
+
+    const x = width > 0 ? anchor.x : mousePos.x;
+    const y = height > 0 ? anchor.y : mousePos.y;
+    const w = Math.abs(width);
+    const h = Math.abs(height);
+
+    setRectSize(this.rectangle, x, y, w, h);
+    setRectMaskSize(this.mask, this.env.image, x, y, w, h);
+    setFormatterElSize(this.elementGroup, x, y, w, h);
+
+    // Anchor (=opposite handle) stays in place, dragged handle moves with mouse
+    this.setHandleXY(this.handles[draggedHandleIdx], mousePos.x, mousePos.y);
+
+    // Handles left and right of the dragged handle
+    const left = this.handles[(draggedHandleIdx + 3) % 4];
+    this.setHandleXY(left, anchor.x, mousePos.y);
+
+    const right = this.handles[(draggedHandleIdx + 5) % 4];
+    this.setHandleXY(right, mousePos.x, anchor.y);*/
+
+  }
+
+  onGrab = grabbedElem => evt => {
+    this.grabbedElem = grabbedElem;
+    const pos = this.getSVGPoint(evt);
+    const { x, y, w, h } = getBBox(this.shape);
+    this.grabbedAt = { x: pos.x - x, y: pos.y - y };
+  }
+
+  onMouseMove = evt => {
+    const constrain = (coord, delta, max) =>
+      coord + delta < 0 ? -coord : (coord + delta > max ? max - coord : delta);
+
+    if (this.grabbedElem) {
+      const pos = this.getSVGPoint(evt);
+
+      const { x, y, width, height } = getBBox(this.shape);
+
+      if (this.grabbedElem === this.shape) {
+
+        const { naturalWidth, naturalHeight } = this.env.image;
+
+        const dx = constrain(x, pos.x - this.grabbedAt.x, naturalWidth - width);
+        const dy = constrain(y, pos.y - this.grabbedAt.y, naturalHeight - height);
+
+        const updatedPoints = getPoints(this.shape).map(pt => ({ x: pt.x + dx, y: pt.y + dy }));
+
+        this.grabbedAt = pos;
+
+        this.setPoints(updatedPoints);
+        
+        this.emit('update', toSVGTarget(this.shape, this.env.image));
+      } else {
+        const handleIdx = this.handles.indexOf(this.grabbedElem);
+        const oppositeHandle = handleIdx < 2 ? 
+          this.handles[handleIdx + 2] : this.handles[handleIdx - 2];
+
+        this.stretchCorners(handleIdx, oppositeHandle, pos);
+
+        this.emit('update', toSVGTarget(this.shape, this.env.image));
+      }
+    }
+  }
+
+  onMouseUp = evt => {
+    this.grabbedElem = null;
+    this.grabbedAt = null;
+  }
+
+  get element() {
+    return this.elementGroup;
+  }
+
+  destroy = () => {
+    this.containerGroup.parentNode.removeChild(this.containerGroup);
+    super.destroy();
+  }
+
+}

--- a/src/freehand/EditableFreehand.js
+++ b/src/freehand/EditableFreehand.js
@@ -111,13 +111,13 @@ export default class EditableFreehand extends EditableShape {
     const outer = this.shape.querySelector('.a9s-outer');
     outer.setAttribute('d', str);
 
+    const { x, y, width, height } = outer.getBBox();
+
     // TODO optional: mask to dim the outside area
     // this.mask.redraw();
 
     // TODO optional: handles to stretch the shape
 /*    const [ topleft, topright, bottomright, bottomleft] = this.handles;
-
-    const { x, y, width, height } = outer.getBBox();
 
     this.setHandleXY(topleft, x, y);
     this.setHandleXY(topright, x + width, y);

--- a/src/freehand/RubberbandFreehand.js
+++ b/src/freehand/RubberbandFreehand.js
@@ -1,0 +1,86 @@
+import { Selection } from '@recogito/annotorious/src/tools/Tool';
+import { toSVGTarget } from '@recogito/annotorious/src/selectors/EmbeddedSVG';
+import { SVG_NAMESPACE } from '@recogito/annotorious/src/util/SVG';
+//import { drawEllipse, setEllipseSize } from './Freehand';
+//import Mask from './EllipseMask';
+
+/**
+ * A 'rubberband' selection tool for creating freehand drawing by
+ * clicking and dragging.
+ */
+export default class RubberbandFreehand {
+
+  constructor(anchor, g, env) {
+    this.points = [ anchor ];
+
+    this.env = env;
+
+    this.group = document.createElementNS(SVG_NAMESPACE, 'g');
+
+    this.freehand = document.createElementNS(SVG_NAMESPACE, 'g');
+    this.freehand.setAttribute('class', 'a9s-selection');
+
+    this.outer = document.createElementNS(SVG_NAMESPACE, 'path');
+    this.outer.setAttribute('class', 'a9s-outer');
+
+    this.inner = document.createElementNS(SVG_NAMESPACE, 'path');
+    this.inner.setAttribute('class', 'a9s-inner');
+
+    this.setPoints(this.points);
+
+//    this.mask = new Mask(env.image, this.inner);
+
+    this.freehand.appendChild(this.outer);
+    this.freehand.appendChild(this.inner);
+
+    // Additionally, selection remains hidden until 
+    // the user actually moves the mouse
+    this.group.style.display = 'none';
+
+//    this.group.appendChild(this.mask.element);
+    this.group.appendChild(this.freehand);
+
+    g.appendChild(this.group);
+  }
+
+  setPoints = points => {
+    var str = points.map(pt => `L${pt[0]} ${pt[1]}`).join(' ');
+    str = 'M' + str.substring(1);
+    this.outer.setAttribute('d', str);
+    this.inner.setAttribute('d', str);
+  }
+
+  getBoundingClientRect = () =>
+    this.outer.getBoundingClientRect();
+
+  dragTo = xy => {
+    // Make visible
+    this.group.style.display = null;
+
+    const rubberband = [ ...this.points, xy ];
+
+    this.setPoints(rubberband);
+//    this.mask.redraw();
+  }
+
+  addPoint = xy => {
+    this.points = [ ...this.points, xy ];
+    this.setPoints(this.points);   
+//    this.mask.redraw();
+  }
+
+  get element() {
+    return this.freehand;
+  }
+
+  destroy = () => {
+    this.group.parentNode.removeChild(this.group);
+    this.freehand = null;    
+    this.group = null;
+  }
+
+  toSelection = () => {
+    return new Selection(toSVGTarget(this.group, this.env.image));
+  }
+
+}

--- a/src/freehand/RubberbandFreehand.js
+++ b/src/freehand/RubberbandFreehand.js
@@ -1,8 +1,8 @@
 import { Selection } from '@recogito/annotorious/src/tools/Tool';
 import { toSVGTarget } from '@recogito/annotorious/src/selectors/EmbeddedSVG';
 import { SVG_NAMESPACE } from '@recogito/annotorious/src/util/SVG';
-//import { drawEllipse, setEllipseSize } from './Freehand';
-//import Mask from './EllipseMask';
+// TODO optional: mask to dim the outside area
+//import Mask from './FreehandMask';
 
 /**
  * A 'rubberband' selection tool for creating freehand drawing by
@@ -28,7 +28,8 @@ export default class RubberbandFreehand {
 
     this.setPoints(this.points);
 
-//    this.mask = new Mask(env.image, this.inner);
+   // TODO optional: mask to dim the outside area
+   // this.mask = new Mask(env.image, this.inner);
 
     this.freehand.appendChild(this.outer);
     this.freehand.appendChild(this.inner);
@@ -37,7 +38,8 @@ export default class RubberbandFreehand {
     // the user actually moves the mouse
     this.group.style.display = 'none';
 
-//    this.group.appendChild(this.mask.element);
+   // TODO optional: mask to dim the outside area
+   // this.group.appendChild(this.mask.element);
     this.group.appendChild(this.freehand);
 
     g.appendChild(this.group);
@@ -57,16 +59,19 @@ export default class RubberbandFreehand {
     // Make visible
     this.group.style.display = null;
 
-    const rubberband = [ ...this.points, xy ];
+    //TODO optional: edge smoothing
 
-    this.setPoints(rubberband);
-//    this.mask.redraw();
+    this.addPoint(xy);
+
+   // TODO optional: mask to dim the outside area
+   // this.mask.redraw();
   }
 
   addPoint = xy => {
     this.points = [ ...this.points, xy ];
     this.setPoints(this.points);   
-//    this.mask.redraw();
+   // TODO optional: mask to dim the outside area
+   // this.mask.redraw();
   }
 
   get element() {

--- a/src/freehand/RubberbandFreehandTool.js
+++ b/src/freehand/RubberbandFreehandTool.js
@@ -1,0 +1,83 @@
+import Tool from '@recogito/annotorious/src/tools/Tool';
+import RubberbandFreehand from './RubberbandFreehand';
+import EditableFreehand from './EditableFreehand';
+
+/**
+ * A rubberband selector for freehand fragments.
+ */
+export default class RubberbandFreehandTool extends Tool {
+
+  constructor(g, config, env) {
+    super(g, config, env);
+
+    this._isDrawing = false;
+  }
+
+  startDrawing = (x, y) => {
+    this._isDrawing = true;
+    
+    this.attachListeners({
+      mouseMove: this.onMouseMove,
+      mouseUp: this.onMouseUp,
+      dblClick: this.onDblClick
+    });
+    
+    this.rubberband = new RubberbandFreehand([ x, y ], this.g, this.env);
+  }
+
+  stop = () => {
+    this.detachListeners();
+    
+    this._isDrawing = false;
+
+    if (this.rubberband) {
+      this.rubberband.destroy();
+      this.rubberband = null;
+    }
+  }
+
+  onMouseMove = (x, y) =>
+    this.rubberband.dragTo([ x, y ]);
+
+  onMouseUp = (x, y) => {
+    const { width, height } = this.rubberband.getBoundingClientRect();
+
+//    const minWidth = this.config.minSelectionWidth || 4;
+//    const minHeight = this.config.minSelectionHeight || 4;
+    
+//    if (width >= minWidth || height >= minHeight) {
+      this.rubberband.addPoint([ x, y ]);
+//    } else {
+//      this.emit('cancel');
+//      this.stop();
+//    }
+  }
+
+  onDblClick = (x, y) => {
+    this._isDrawing = false;
+
+    this.rubberband.addPoint([ x, y ]);
+
+    const shape = this.rubberband.element;
+    shape.annotation = this.rubberband.toSelection();
+    this.emit('complete', shape);
+
+    this.stop();
+  }
+
+  get isDrawing() {
+    return this._isDrawing;
+  }
+
+  createEditableShape = annotation =>
+    new EditableFreehand(annotation, this.g, this.config, this.env);
+
+}
+
+RubberbandFreehandTool.identifier = 'freehand';
+
+RubberbandFreehandTool.supports = annotation => {
+  const selector = annotation.selector('SvgSelector');
+  if (selector)
+    return selector.value?.match(/^<svg.*<path/g);
+}

--- a/src/freehand/RubberbandFreehandTool.js
+++ b/src/freehand/RubberbandFreehandTool.js
@@ -40,17 +40,7 @@ export default class RubberbandFreehandTool extends Tool {
     this.rubberband.dragTo([ x, y ]);
 
   onMouseUp = (x, y) => {
-    const { width, height } = this.rubberband.getBoundingClientRect();
-
-//    const minWidth = this.config.minSelectionWidth || 4;
-//    const minHeight = this.config.minSelectionHeight || 4;
-    
-//    if (width >= minWidth || height >= minHeight) {
-      this.rubberband.addPoint([ x, y ]);
-//    } else {
-//      this.emit('cancel');
-//      this.stop();
-//    }
+    this.onDblClick(x, y);
   }
 
   onDblClick = (x, y) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
 import RubberbandCircleTool from './circle/RubberbandCircleTool';
 import RubberbandEllipseTool from './ellipse/RubberbandEllipseTool';
+import RubberbandFreehandTool from './freehand/RubberbandFreehandTool';
 
 const SelectorPack = (anno, config) => {
 
   anno.addDrawingTool(RubberbandCircleTool);
   anno.addDrawingTool(RubberbandEllipseTool);
+  anno.addDrawingTool(RubberbandFreehandTool);
   
 }
 


### PR DESCRIPTION
Relies on https://github.com/recogito/annotorious/pull/137 to be accepted first. Not compatible with Annotorious v2.4.2, so people will have to build Annotorious from source for now to use the freehand tool. As such, I would suggest to put this feature in a separate selector pack branch until support for the freehand drawing tool has been released.

A couple of features have not (yet) been implemented:
- A mask to dim the outside area.
- Handles to stretch the shape.
- (Configurable) smoothing of the drawing.

I probably won't implement these features just yet, as I'm not sure how useful they are. Feel free to open the appropriate issues if you believe they should be added, but I can't promise I'll take them up at this time.