### PR TITLE
Fixes zero-length freehand drawings

### DIFF
--- a/src/freehand/RubberbandFreehandTool.js
+++ b/src/freehand/RubberbandFreehandTool.js
@@ -48,9 +48,22 @@ export default class RubberbandFreehandTool extends Tool {
 
     this.rubberband.addPoint([ x, y ]);
 
-    const shape = this.rubberband.element;
-    shape.annotation = this.rubberband.toSelection();
-    this.emit('complete', shape);
+    this.detachListeners();
+
+    const { width, height } = this.rubberband.getBoundingClientRect();
+
+    const minWidth = this.config.minSelectionWidth || 4;
+    const minHeight = this.config.minSelectionHeight || 4;
+
+    if (width >= minWidth || height >= minHeight) {
+
+      const shape = this.rubberband.element;
+      shape.annotation = this.rubberband.toSelection();
+
+      this.emit('complete', shape);
+    } else {
+      this.emit('cancel');
+    }
 
     this.stop();
   }


### PR DESCRIPTION
Unlike other shapes, I chose to use either a minimum width _or_ a minimum height, instead of a minimum for both. Perhaps someone wants to create a very short straight line with a minimal width/height. Feel free to provide arguments to not use this slightly different approach.