### PR TITLE
Pin circle's starting point and prevent overflow

### DIFF
--- a/src/circle/CircleMask.js
+++ b/src/circle/CircleMask.js
@@ -10,22 +10,23 @@ export default class CircleMask {
     this.circle = circle;
 
     const { cx, cy, r } = getCircleSize(this.circle);
-
-    const ty = cy + r;
+    const tx = ((cx + r) > this.w) ? this.w - r : cx;
+    const ty = ((cy + r) > this.h) ? this.h - r : cy + r;
 
     this.mask = document.createElementNS(SVG_NAMESPACE, 'path');
     this.mask.setAttribute('fill-rule', 'evenodd');    
     this.mask.setAttribute('class', 'a9s-selection-mask');
 
-    this.mask.setAttribute('d', `M0 0 h${this.w} v${this.h} h-${this.w} z M${cx} ${ty} a ${r} ${r} 0 1 1 1 0`);
+    this.mask.setAttribute('d', `M0 0 h${this.w} v${this.h} h-${this.w} z M${tx} ${ty} a ${r} ${r} 0 1 1 1 0`);
   }
 
   redraw = () => {
     const { cx, cy, r } = getCircleSize(this.circle);
 
-    const ty = cy + r;
+    const tx = ((cx + r) > this.w) ? this.w - r : cx;
+    const ty = ((cy + r) > this.h) ? this.h - r : cy + r;
 
-    this.mask.setAttribute('d', `M0 0 h${this.w} v${this.h} h-${this.w} z M${cx} ${ty} a ${r} ${r} 0 1 1 1 0`);
+    this.mask.setAttribute('d', `M0 0 h${this.w} v${this.h} h-${this.w} z M${tx} ${ty} a ${r} ${r} 0 1 1 1 0`);
   }
 
   get element() {

--- a/src/circle/EditableCircle.js
+++ b/src/circle/EditableCircle.js
@@ -162,8 +162,8 @@ export default class EditableCircle extends EditableShape {
 
         const { naturalWidth, naturalHeight } = this.env.image;
 
-        const cx = constrain(pos.x - this.grabbedAt.x, naturalWidth - r);
-        const cy = constrain(pos.y - this.grabbedAt.y, naturalHeight - r);
+        const cx = Math.max(constrain(pos.x - this.grabbedAt.x, naturalWidth - r), r);
+        const cy = Math.max(constrain(pos.y - this.grabbedAt.y, naturalHeight - r), r);
 
         this.setSize(cx, cy, r); 
         this.emit('update', toSVGTarget(this.circle, this.env.image)); 

--- a/src/circle/RubberbandCircle.js
+++ b/src/circle/RubberbandCircle.js
@@ -42,17 +42,20 @@ export default class RubberbandCircle {
   }
 
   dragTo = (oppositeX, oppositeY) => {
+    const { naturalWidth, naturalHeight } = this.env.image;
+
     // Make visible
     this.group.style.display = null;
 
     const w = oppositeX - this.anchor[0];
     const h = oppositeY - this.anchor[1];
+    const r = Math.max(1, Math.pow(w ** 2 + h ** 2, 0.5) / 2);
 
-    const cx = w > 0 ? this.anchor[0] + w / 2 : oppositeX + w / 2;
-    const cy = h > 0 ? this.anchor[1] + h / 2 : oppositeY + h / 2;
+    const cx = this.anchor[0] + w / 2;
+    const cy = this.anchor[1] + h / 2;
 
-    const r = Math.max(1, Math.pow(w ** 2 + h ** 2, 0.5) / 2); // Negative values
-
+    if ((cx-r < 0 || cx + r > naturalWidth) || (cy-r < 0 || cy + r > naturalHeight)) return;
+    
     setCircleSize(this.circle, cx, cy, r);
     this.mask.redraw();
   }


### PR DESCRIPTION
I pinned the starting point of circle and prevented shape overflowing.


Additionally, I tried to prevent shape overflow while drawing circle by calculating `cx`, `cy`, `r` from formula but failed(Prevented overflow successfully on the Y axis, but not X-axis).
```
// many codes...
    } else if (cy + r > naturalHeight) {
      // radius = naturalHeight - cy
      const a = 1, b = -2*((A**2+1)*this.anchor[1]-A**2*naturalHeight), c = (A**2+1)*this.anchor[1]**2-A**2*naturalHeight**2;
      cy = getRoot(this.anchor[1], oppositeY, getRootCandidates(a, b, c));
      console.log("case 4: ", getRootCandidates(a, b, c))
      cx = (A===0) ? this.anchor[0] + naturalHeight - cy : (cy-B)/A;
      r = naturalHeight - cy;
    }
```

So, I just prevented number of cases with `return`.

RubberbandCircle.js - line:57
```
if ((cx-r < 0 || cx + r > naturalWidth) || (cy-r < 0 || cy + r > naturalHeight)) return;
```
I don't know whether it's normal behavior or not. So, if it is abnormal procedure,  I'd appreciate it if you could let me know.

