### PR TITLE
added vue setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,57 @@ You can set the tools to include when initializing the plugin.
 
 ```js
 // Will only include ellipse and freehand, but not circle
-Annotorious.SelectorPack(anno, { 
+Annotorious.SelectorPack(anno, {
   tools: ['ellipse', 'freehand']
 });
 ```
+## Installation  with npm
+```
+npm i @recogito/annotorious-selector-pack
+
+```
+
+## Using with VueJS
+Install package at project root with npm
+
+```html
+<template>
+  <div>
+    <img id="plan" src="img.png" style="width: 100%; max-width: 1024px;" />
+  </div>
+</template>
+
+<script>
+  import { Annotorious} from '@recogito/annotorious';
+  import '@recogito/annotorious/dist/annotorious.min.css';
+  import  SelectorPack  from '@recogito/annotorious-selector-pack';
+
+  export default {
+
+    data() {
+      return {
+        anno: null
+      }
+    },
+
+    methods: {
+      initAnno() {
+        this.anno = new Annotorious({
+          image: document.getElementById("plan")
+        });
+      }
+    },
+
+    mounted() {
+      this.initAnno();
+      SelectorPack(this.anno)
+    }
+  }
+</script>
+```
+
+
+
 
 ## Development
 


### PR DESCRIPTION
I spent an unreasonable amount of time figuring out how to make this work with Vue

Initial annotorious setup was simple thanks to this [guide from the documentation](https://recogito.github.io/guides/annotorious-in-vue/) But figuring out how to add these new selectors was rough with the documentation provided.

I added a minimal working example to the README for how to install and set up annotorious and the selector pack in a vue project. If you don't think it's appropriate for the main readme, if it can be added to the documentation somewhere I think it may save someone a headache in the future.

Thank you for making this super useful tool